### PR TITLE
Add indexed into  Lockedup event 

### DIFF
--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -51,7 +51,7 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		uint256 interest;
 		uint256 holdersCap;
 	}
-	event Lockedup(address _from, address _property, uint256 _value);
+	event Lockedup(address indexed _from, address indexed _property, uint256 _value);
 	event Withdrew(
 		address indexed _from,
 		address indexed _property,

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -52,6 +52,7 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		uint256 holdersCap;
 	}
 	event Lockedup(address _from, address _property, uint256 _value);
+	event Withdrew(address indexed _from, address indexed _property, uint256 _value, uint256 _reward);
 	event UpdateCap(uint256 _cap);
 
 	uint256 public override cap; // From [get/set]StorageCap
@@ -282,6 +283,8 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		 */
 		updateValues(false, property, _amount, prices);
 		uint256 cumulative = cumulativeReward.add(value);
+
+		emit Withdraw(msg.sender, property, _amount, value);
 		/**
 		 * update position information
 		 */

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -51,7 +51,11 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		uint256 interest;
 		uint256 holdersCap;
 	}
-	event Lockedup(address indexed _from, address indexed _property, uint256 _value);
+	event Lockedup(
+		address indexed _from,
+		address indexed _property,
+		uint256 _value
+	);
 	event Withdrew(
 		address indexed _from,
 		address indexed _property,

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -289,7 +289,7 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		updateValues(false, property, _amount, prices);
 		uint256 cumulative = cumulativeReward.add(value);
 
-		emit Withdraw(msg.sender, property, _amount, value);
+		emit Withdrew(msg.sender, property, _amount, value);
 		/**
 		 * update position information
 		 */

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -52,7 +52,12 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 		uint256 holdersCap;
 	}
 	event Lockedup(address _from, address _property, uint256 _value);
-	event Withdrew(address indexed _from, address indexed _property, uint256 _value, uint256 _reward);
+	event Withdrew(
+		address indexed _from,
+		address indexed _property,
+		uint256 _value,
+		uint256 _reward
+	);
 	event UpdateCap(uint256 _cap);
 
 	uint256 public override cap; // From [get/set]StorageCap

--- a/test/lockup/lockup-s-token.ts
+++ b/test/lockup/lockup-s-token.ts
@@ -293,6 +293,26 @@ contract('LockupTest', ([deployer, user1, user2, user3]) => {
 				)
 				expect(beforePosition[4].toNumber()).to.be.equal(0)
 			})
+			it('generate event.', async () => {
+				const [dev, property, tokenId] = await init2()
+				const t1 = await getBlockTimestamp()
+				await forwardBlockTimestamp(1)
+				dev.lockup.withdrawByPosition(tokenId, 100)
+				const [_from, _property, _value, _reward] = await Promise.all([
+					getEventValue(dev.lockup)('Withdrew', '_from'),
+					getEventValue(dev.lockup)('Withdrew', '_property'),
+					getEventValue(dev.lockup)('Withdrew', '_value'),
+					getEventValue(dev.lockup)('Withdrew', '_reward'),
+				])
+				expect(_from).to.be.equal(deployer)
+				expect(_property).to.be.equal(property.address)
+				expect(_value).to.be.equal('100')
+				const t2 = await getBlockTimestamp()
+				const reward = toBigNumber('10000000000000000000')
+					.times(t2 - t1)
+					.toFixed()
+				expect(_reward).to.be.equal(reward)
+			})
 			it('get reward.', async () => {
 				const [dev, , tokenId] = await init2()
 				const t1 = await getBlockTimestamp()


### PR DESCRIPTION
# Description

[ Please write here what changes this pull request ]
add indexed into _from and _property of Lockedup event in Lockup.sol
# Why

[ Please write here about why needs this change ]
_from and _property of Withrew event have been indexed. So i though it will be useful that Lockedup event will be also searched with indexed.
# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/protocol/blob/main/CODE_OF_CONDUCT.md) 🖖
