### PR TITLE
Add interface: MetricsFactory.metricsOfProperty

### DIFF
--- a/contracts/interface/IMetricsFactory.sol
+++ b/contracts/interface/IMetricsFactory.sol
@@ -27,6 +27,11 @@ interface IMetricsFactory {
 		view
 		returns (uint256);
 
+	function metricsPerProperty(address _property)
+		external
+		view
+		returns (address[] memory);
+
 	function hasAssets(address _property) external view returns (bool);
 
 	function authenticatedPropertiesCount() external view returns (uint256);

--- a/contracts/interface/IMetricsFactory.sol
+++ b/contracts/interface/IMetricsFactory.sol
@@ -27,7 +27,7 @@ interface IMetricsFactory {
 		view
 		returns (uint256);
 
-	function metricsPerProperty(address _property)
+	function metricsOfProperty(address _property)
 		external
 		view
 		returns (address[] memory);

--- a/contracts/src/metrics/MetricsFactory.sol
+++ b/contracts/src/metrics/MetricsFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 pragma solidity =0.8.9;
 
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../../interface/IMetrics.sol";
 import "../../interface/IMetricsFactory.sol";
 import "../../interface/IMarketFactory.sol";
@@ -14,7 +15,9 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 	uint256 public override metricsCount;
 	uint256 public override authenticatedPropertiesCount;
 	mapping(address => bool) public override isMetrics;
-	mapping(address => uint256) public override metricsCountPerProperty;
+	mapping(address => EnumerableSet.AddressSet) internal metricsPerProperty_;
+
+	using EnumerableSet for EnumerableSet.AddressSet;
 
 	/**
 	 * Initialize the passed address as AddressRegistry address.
@@ -86,26 +89,44 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 		emit Destroy(msg.sender, IMetrics(_metrics).property(), _metrics);
 	}
 
+	function metricsCountPerProperty(address _property)
+		external
+		view
+		override
+		returns (uint256)
+	{
+		return metricsPerProperty_[_property].length();
+	}
+
+	function metricsPerProperty(address _property)
+		external
+		view
+		override
+		returns (address[] memory)
+	{
+		return metricsPerProperty_[_property].values();
+	}
+
 	function _addMetrics(address _addr) internal {
 		isMetrics[_addr] = true;
 		address property = IMetrics(_addr).property();
-		uint256 countPerProperty = metricsCountPerProperty[property];
+		uint256 countPerProperty = metricsPerProperty_[property].length();
 		if (countPerProperty == 0) {
 			authenticatedPropertiesCount = authenticatedPropertiesCount + 1;
 		}
 		metricsCount = metricsCount + 1;
-		metricsCountPerProperty[property] = countPerProperty + 1;
+		metricsPerProperty_[property].add(_addr);
 	}
 
 	function _removeMetrics(address _addr) internal {
 		isMetrics[_addr] = false;
 		address property = IMetrics(_addr).property();
-		uint256 countPerProperty = metricsCountPerProperty[property];
+		uint256 countPerProperty = metricsPerProperty_[property].length();
 		if (countPerProperty == 1) {
 			authenticatedPropertiesCount = authenticatedPropertiesCount - 1;
 		}
 		metricsCount = metricsCount - 1;
-		metricsCountPerProperty[property] = countPerProperty - 1;
+		metricsPerProperty_[property].remove(_addr);
 	}
 
 	function hasAssets(address _property)
@@ -114,6 +135,6 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 		override
 		returns (bool)
 	{
-		return metricsCountPerProperty[_property] > 0;
+		return metricsPerProperty_[_property].length() > 0;
 	}
 }

--- a/contracts/src/metrics/MetricsFactory.sol
+++ b/contracts/src/metrics/MetricsFactory.sol
@@ -15,7 +15,7 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 	uint256 public override metricsCount;
 	uint256 public override authenticatedPropertiesCount;
 	mapping(address => bool) public override isMetrics;
-	mapping(address => EnumerableSet.AddressSet) internal metricsPerProperty_;
+	mapping(address => EnumerableSet.AddressSet) internal metricsOfProperty_;
 
 	using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -95,38 +95,38 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 		override
 		returns (uint256)
 	{
-		return metricsPerProperty_[_property].length();
+		return metricsOfProperty_[_property].length();
 	}
 
-	function metricsPerProperty(address _property)
+	function metricsOfProperty(address _property)
 		external
 		view
 		override
 		returns (address[] memory)
 	{
-		return metricsPerProperty_[_property].values();
+		return metricsOfProperty_[_property].values();
 	}
 
 	function _addMetrics(address _addr) internal {
 		isMetrics[_addr] = true;
 		address property = IMetrics(_addr).property();
-		uint256 countPerProperty = metricsPerProperty_[property].length();
+		uint256 countPerProperty = metricsOfProperty_[property].length();
 		if (countPerProperty == 0) {
 			authenticatedPropertiesCount = authenticatedPropertiesCount + 1;
 		}
 		metricsCount = metricsCount + 1;
-		metricsPerProperty_[property].add(_addr);
+		metricsOfProperty_[property].add(_addr);
 	}
 
 	function _removeMetrics(address _addr) internal {
 		isMetrics[_addr] = false;
 		address property = IMetrics(_addr).property();
-		uint256 countPerProperty = metricsPerProperty_[property].length();
+		uint256 countPerProperty = metricsOfProperty_[property].length();
 		if (countPerProperty == 1) {
 			authenticatedPropertiesCount = authenticatedPropertiesCount - 1;
 		}
 		metricsCount = metricsCount - 1;
-		metricsPerProperty_[property].remove(_addr);
+		metricsOfProperty_[property].remove(_addr);
 	}
 
 	function hasAssets(address _property)
@@ -135,6 +135,6 @@ contract MetricsFactory is InitializableUsingRegistry, IMetricsFactory {
 		override
 		returns (bool)
 	{
-		return metricsPerProperty_[_property].length() > 0;
+		return metricsOfProperty_[_property].length() > 0;
 	}
 }

--- a/contracts/test/metrics/MetricsFactoryTest.sol
+++ b/contracts/test/metrics/MetricsFactoryTest.sol
@@ -24,9 +24,9 @@ contract MetricsFactoryTest is MetricsFactory {
 		public
 	{
 		if (_zeroOrOne == 0) {
-			metricsPerProperty_[_addr].remove(address(1));
+			metricsOfProperty_[_addr].remove(address(1));
 		} else {
-			metricsPerProperty_[_addr].add(address(1));
+			metricsOfProperty_[_addr].add(address(1));
 		}
 	}
 }

--- a/contracts/test/metrics/MetricsFactoryTest.sol
+++ b/contracts/test/metrics/MetricsFactoryTest.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 pragma solidity =0.8.9;
 
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../../src/metrics/MetricsFactory.sol";
 
 /**
  * A factory contract that creates a new Market contract.
  */
 contract MetricsFactoryTest is MetricsFactory {
+	using EnumerableSet for EnumerableSet.AddressSet;
+
 	constructor() MetricsFactory() {}
 
 	function __addMetrics(address _addr) public {
@@ -17,9 +20,13 @@ contract MetricsFactoryTest is MetricsFactory {
 		_removeMetrics(_addr);
 	}
 
-	function __setMetricsCountPerProperty(address _addr, uint256 _value)
+	function __setMetricsCountPerProperty(address _addr, uint8 _zeroOrOne)
 		public
 	{
-		metricsCountPerProperty[_addr] = _value;
+		if (_zeroOrOne == 0) {
+			metricsPerProperty_[_addr].remove(address(1));
+		} else {
+			metricsPerProperty_[_addr].add(address(1));
+		}
 	}
 }

--- a/test/metrics/metrics-factory.ts
+++ b/test/metrics/metrics-factory.ts
@@ -69,11 +69,11 @@ contract(
 					await dev.metricsFactory.metricsCount().then((x) => x.toNumber())
 				).to.be.equal(2)
 			})
-			it('Should to be increased metricsPerProperty always', async () => {
+			it('Should to be increased metricsOfProperty always', async () => {
 				const [dev] = await init()
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(0)
 				const m1 = await dev.metricsFactory
@@ -83,7 +83,7 @@ contract(
 					.then(getMetricsAddress)
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(1)
 
@@ -94,12 +94,12 @@ contract(
 					.then(getMetricsAddress)
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(2)
-				expect(
-					await dev.metricsFactory.metricsPerProperty(property1)
-				).to.be.eql([m1, m2])
+				expect(await dev.metricsFactory.metricsOfProperty(property1)).to.be.eql(
+					[m1, m2]
+				)
 			})
 			it('Should to be increased metricsCountPerProperty always', async () => {
 				const [dev] = await init()
@@ -250,7 +250,7 @@ contract(
 					await dev.metricsFactory.metricsCount().then((x) => x.toNumber())
 				).to.be.equal(0)
 			})
-			it('Should to be decerased metricsPerProperty always', async () => {
+			it('Should to be decerased metricsOfProperty always', async () => {
 				const [dev] = await init()
 				const m1 = await dev.metricsFactory
 					.create(property1, {
@@ -264,7 +264,7 @@ contract(
 					.then(getMetricsAddress)
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(2)
 
@@ -273,7 +273,7 @@ contract(
 				})
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(1)
 
@@ -282,12 +282,12 @@ contract(
 				})
 				expect(
 					await dev.metricsFactory
-						.metricsPerProperty(property1)
+						.metricsOfProperty(property1)
 						.then((x) => x.length)
 				).to.be.equal(0)
-				expect(
-					await dev.metricsFactory.metricsPerProperty(property1)
-				).to.be.eql([])
+				expect(await dev.metricsFactory.metricsOfProperty(property1)).to.be.eql(
+					[]
+				)
 			})
 			it('Should to be decreased metricsCountPerProperty always', async () => {
 				const [dev] = await init()

--- a/test/metrics/metrics-factory.ts
+++ b/test/metrics/metrics-factory.ts
@@ -69,6 +69,38 @@ contract(
 					await dev.metricsFactory.metricsCount().then((x) => x.toNumber())
 				).to.be.equal(2)
 			})
+			it('Should to be increased metricsPerProperty always', async () => {
+				const [dev] = await init()
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(0)
+				const m1 = await dev.metricsFactory
+					.create(property1, {
+						from: market,
+					})
+					.then(getMetricsAddress)
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(1)
+
+				const m2 = await dev.metricsFactory
+					.create(property1, {
+						from: market,
+					})
+					.then(getMetricsAddress)
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(2)
+				expect(
+					await dev.metricsFactory.metricsPerProperty(property1)
+				).to.be.eql([m1, m2])
+			})
 			it('Should to be increased metricsCountPerProperty always', async () => {
 				const [dev] = await init()
 				expect(
@@ -217,6 +249,45 @@ contract(
 				expect(
 					await dev.metricsFactory.metricsCount().then((x) => x.toNumber())
 				).to.be.equal(0)
+			})
+			it('Should to be decerased metricsPerProperty always', async () => {
+				const [dev] = await init()
+				const m1 = await dev.metricsFactory
+					.create(property1, {
+						from: market,
+					})
+					.then(getMetricsAddress)
+				const m2 = await dev.metricsFactory
+					.create(property1, {
+						from: market,
+					})
+					.then(getMetricsAddress)
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(2)
+
+				await dev.metricsFactory.destroy(m1, {
+					from: market,
+				})
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(1)
+
+				await dev.metricsFactory.destroy(m2, {
+					from: market,
+				})
+				expect(
+					await dev.metricsFactory
+						.metricsPerProperty(property1)
+						.then((x) => x.length)
+				).to.be.equal(0)
+				expect(
+					await dev.metricsFactory.metricsPerProperty(property1)
+				).to.be.eql([])
 			})
 			it('Should to be decreased metricsCountPerProperty always', async () => {
 				const [dev] = await init()


### PR DESCRIPTION
# Description

Add enum `metricsOfProperty` to MetricsFactory.

# Why

Dapps can only get the metrics associated with a Property using an off-chain server such as GraphQL.

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/protocol/blob/main/CODE_OF_CONDUCT.md) 🖖
